### PR TITLE
Fix bug where gridSize gets set to an even number

### DIFF
--- a/simple-explosion.js
+++ b/simple-explosion.js
@@ -13,7 +13,8 @@ function setup() {
 }
 
 function draw() {
-    gridSize = slider.value()
+    // Only set gridSize to odd numbers
+    gridSize = 2 * Math.floor(slider.value()/2) + 1
     background(0, 195, 192);
     drawCircles(gridSize)
 


### PR DESCRIPTION
If gridSize is an even number then there is no central square to start the explosion from. This leaves the animation looking quite janky